### PR TITLE
add install_options for gem installation

### DIFF
--- a/manifests/hiera/eyaml.pp
+++ b/manifests/hiera/eyaml.pp
@@ -1,10 +1,12 @@
 class puppetserver::hiera::eyaml (
-  $method = 'pkcs7',
+  $method          = 'pkcs7',
+  $install_options = undef,
 ) {
   Package {
-    ensure   => present,
-    provider => puppetserver_gem,
-    notify   => Class['puppetserver::service'],
+    ensure          => present,
+    provider        => puppetserver_gem,
+    install_options => $install_options,
+    notify          => Class['puppetserver::service'],
   }
 
   case $method {


### PR DESCRIPTION
Hello, 

This commit adds the ability to specify an install_option, to specify a http proxy for example.

```
class { '::puppetserver::hiera::eyaml':
  install_options => [{"--http-proxy" => "http://squid:3128"}],
  require         => Class['puppetserver::install'],
}
```

Regards

Olivier
