### PR TITLE
Switching to use a 40 character key

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -27,7 +27,7 @@ class puppetserver::repository (
       apt::source { 'puppetlabs':
         location   => 'http://apt.puppetlabs.com',
         repos      => 'main',
-        key        => '4BD6EC30',
+        key        => '80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6',
         key_server => 'pgp.mit.edu',
       }
     }


### PR DESCRIPTION
I get a warning from the apt module trying to run this with such a short key - which recommended upgrading to the full 40 character key.

Upgrading to use that key solved the problem :)