### PR TITLE
Set min version_requirement for Puppet + deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,28 +1,34 @@
 {
-  "name": "camptocamp-puppetserver",
+  "name": "puppet-puppetserver",
   "version": "2.1.0",
-  "author": "camptocamp",
+  "author": "Vox Pupuli",
   "summary": "Puppet module for puppetserver",
   "license": "Apache-2.0",
-  "source": "https://github.com/camptocamp/puppet-puppetserver",
-  "project_page": "https://github.com/camptocamp/puppet-puppetserver",
-  "issues_url": "https://github.com/camptocamp/puppet-puppetserver/issues",
+  "source": "https://github.com/voxpupuli/puppet-puppetserver",
+  "project_page": "https://github.com/voxpupuli/puppet-puppetserver",
+  "issues_url": "https://github.com/voxpupuli/puppet-puppetserver/issues",
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_core",
-      "version_requirement": "2.x"
+      "version_requirement": ">=2.1.3 < 3.0.0"
     },
     {
       "name": "camptocamp/augeas",
-      "version_requirement": "1.x"
+      "version_requirement": ">=1.5.1 < 2.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.0.0 <3.0.0"
+      "version_requirement": ">=2.1.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=4.6.0 < 5.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata

Also fix namespacing