### PR TITLE
bump dep on apt to '< 5.0.0'; use long gpg id

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -25,10 +25,12 @@ class puppetserver::repository (
     'Debian': {
       include ::apt
       apt::source { 'puppetlabs':
-        location   => 'http://apt.puppetlabs.com',
-        repos      => 'main',
-        key        => '4BD6EC30',
-        key_server => 'pgp.mit.edu',
+        location => 'http://apt.puppetlabs.com',
+        repos    => 'main',
+        key      => {
+            id     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+            server => 'pgp.mit.edu',
+        },
       }
     }
     'RedHat': {

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.1.0 < 3.0.0"
+      "version_requirement": ">=2.1.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/puppetserver_gem",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

Newer versions require only one simple change on puppetserver's side: replace `key` and `key_server` string parameters with the `key` hash parameter. The former were already deprecated in the minimal supported version (2.1.0).
Took the chance and changed `apt::source` to use the full GPG key fingerprint, to avoid warnings.