### PR TITLE
Fix path for puppetserver config and add  max-active-instances

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -35,5 +35,10 @@ class puppetserver::config {
       setting_type => 'array',
       type         => 'puppetserver',
       ;
+
+    'puppetserver/max-active-instances':
+      setting => 'puppetserver.conf/jruby-puppet/max-active-instances',
+      type    => 'puppetserver',
+      ;
   }
 }


### PR DESCRIPTION
### You can tune
 refs: Number of JRubies
https://puppet.com/docs/puppetserver/latest/tuning_guide.html#number-of-jrubies

Thank you for considering the following.

### puppetserver::config::puppetserver
A Puppetserver configuration entry.

Example: hieradta

```yaml
puppetserver::config:
  puppetserver:
    max-active-instances: 2
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
