### PR TITLE
Change keyserver to pool.sks-keyservers.net

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -29,7 +29,7 @@ class puppetserver::repository (
         repos    => 'main',
         key      => {
             id     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-            server => 'pgp.mit.edu',
+            server => 'pool.sks-keyservers.net',
         },
       }
     }


### PR DESCRIPTION
#### Pull Request (PR) description
Change the keyserver to use SKS keyserver pools. The old keyserver (pgp.mit.edu) is included in the SKS keyservers pool


#### This Pull Request (PR) fixes the following issues
Periodic fails at install time when the pgp.mit.edu server is overloaded and don't respond anymore
